### PR TITLE
Implement the solution for cleware service to access USB device on Linux platform

### DIFF
--- a/build/Linux/opt/devatserv/share/start-services/docker-compose.yml
+++ b/build/Linux/opt/devatserv/share/start-services/docker-compose.yml
@@ -36,6 +36,10 @@ services:
     healthcheck:
       interval: 10s
       timeout: 5s
+    devices:
+      - "/dev/usb/hiddev0:/dev/usb/hiddev0"
+    stdin_open: true
+    tty: true
 
   service-base:
     image: "devatserv-service-base"

--- a/docker-compose.gitlab.yml
+++ b/docker-compose.gitlab.yml
@@ -38,6 +38,10 @@ services:
     healthcheck:
       interval: 10s
       timeout: 5s
+    devices:
+      - "/dev/usb/hiddev0:/dev/usb/hiddev0"
+    stdin_open: true
+    tty: true
 
   service-base:
     container_name: base-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,10 @@ services:
     healthcheck:
       interval: 10s
       timeout: 5s
+    devices:
+      - "/dev/usb/hiddev0:/dev/usb/hiddev0"
+    stdin_open: true
+    tty: true
 
   service-base:
     container_name: base-service


### PR DESCRIPTION
Hi Thomas,

I would like to update the docker compose configuration to connect USB with Cleware devices on Linux platforms.
Please help me merge it.
Ticket: https://github.com/test-fullautomation/DevAtServ/issues/7

Thank you and best regards,
Thong Hua